### PR TITLE
Fix menu lock-up

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -26,14 +26,18 @@ pub fn handle(greeter: &mut Greeter, events: &Events) -> Result<(), Box<dyn Erro
       Key::Right => greeter.cursor_offset += 1,
 
       Key::F(2) => {
-        greeter.new_command = greeter.command.clone().unwrap_or_default();
-        greeter.previous_mode = greeter.mode;
-        greeter.mode = Mode::Command;
+        if greeter.mode != Mode::Sessions && greeter.mode != Mode::Command {
+          greeter.new_command = greeter.command.clone().unwrap_or_default();
+          greeter.previous_mode = greeter.mode;
+          greeter.mode = Mode::Command;
+        }
       }
 
       Key::F(3) => {
-        greeter.previous_mode = greeter.mode;
-        greeter.mode = Mode::Sessions;
+        if greeter.mode != Mode::Sessions && greeter.mode != Mode::Command {
+          greeter.previous_mode = greeter.mode;
+          greeter.mode = Mode::Sessions;
+        }
       }
 
       Key::Up => {


### PR DESCRIPTION
If you open one of the two currently present menues with either F2 or F3
and then open another one of these two menues again, it triggers a bug
that you can't exit these dialog menues any longer. This is a very crude
fix since I'm very new to rust. You might wish to refine this further
but for now it fixes #8