### PR TITLE
Bugfix in time formatting

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -101,7 +101,7 @@ pub fn draw(terminal: &mut Terminal<TermionBackend<RawTerminal<io::Stdout>>>, gr
 }
 
 fn get_time() -> String {
-  Local::now().format("%b, %d %h %Y - %H:%M").to_string()
+  Local::now().format("%a, %d %h %Y - %H:%M").to_string()
 }
 
 fn status_label<'s, S>(text: S) -> Span<'s>


### PR DESCRIPTION
The current time formatting is incorrct. 
The first one should be the day in a week but currently it's month.
This can also be seen from the screenshot in README, which has "Jul, 4 Jul 2020".
This PR fixes this by using the proper `%a` for day, e.g. for today it gives below
![image](https://user-images.githubusercontent.com/5985769/117137438-9bca5300-ada1-11eb-9137-7b36a4604b6e.png)
