### PR TITLE
Remove busy-wait in async read of `greeter.power_command` Fixes #44

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -14,7 +14,7 @@ use i18n_embed::DesktopLanguageRequester;
 use tokio::{
   net::UnixStream,
   process::Command,
-  sync::{RwLock, RwLockWriteGuard},
+  sync::{Notify, RwLock, RwLockWriteGuard},
 };
 use zeroize::Zeroize;
 
@@ -87,6 +87,7 @@ pub struct Greeter {
 
   pub power_commands: HashMap<PowerOption, String>,
   pub power_command: Option<Command>,
+  pub power_command_notify: Arc<Notify>,
   pub power_setsid: bool,
 
   pub working: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,16 +70,17 @@ async fn run() -> Result<(), Box<dyn Error>> {
 
   tokio::task::spawn({
     let greeter = greeter.clone();
+    let notify = greeter.read().await.power_command_notify.clone();
 
     async move {
       loop {
+        notify.notified().await;
+
         let command = greeter.write().await.power_command.take();
 
         if let Some(command) = command {
           power::run(&greeter, command).await;
         }
-        
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await
       }
     }
   });

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,8 @@ async fn run() -> Result<(), Box<dyn Error>> {
         if let Some(command) = command {
           power::run(&greeter, command).await;
         }
+        
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await
       }
     }
   });

--- a/src/power.rs
+++ b/src/power.rs
@@ -50,6 +50,7 @@ pub fn power(greeter: &mut Greeter, option: PowerOption) {
   };
 
   greeter.power_command = Some(command);
+  greeter.power_command_notify.notify_one();
 }
 
 pub async fn run(greeter: &Arc<RwLock<Greeter>>, mut command: Command) {


### PR DESCRIPTION
Added a 100ms sleep to `power_command` loop
This was done to prevent a spinloop from continuously taking up CPU time