### PR TITLE
Automatically add 'startx' to xsession entries

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -166,7 +166,7 @@ pub fn get_sessions(greeter: &Greeter) -> Result<Vec<(String, String)>, Box<dyn 
   let mut files = sessions
     .iter()
     .flat_map(fs::read_dir)
-    .flat_map(|directory| directory.flat_map(|entry| entry.map(|entry| load_desktop_file(entry.path()))).flatten())
+    .flat_map(|directory| directory.flat_map(|entry| entry.map(|entry| load_desktop_file(entry.path(), entry.path().parent().unwrap().ends_with("xsessions")))).flatten())
     .collect::<Vec<_>>();
 
   if let Some(command) = &greeter.command {
@@ -176,7 +176,7 @@ pub fn get_sessions(greeter: &Greeter) -> Result<Vec<(String, String)>, Box<dyn 
   Ok(files)
 }
 
-fn load_desktop_file<P>(path: P) -> Result<(String, String), Box<dyn Error>>
+fn load_desktop_file<P>(path: P, needs_xorg: bool) -> Result<(String, String), Box<dyn Error>>
 where
   P: AsRef<Path>,
 {
@@ -185,7 +185,9 @@ where
 
   let name = section.get("Name").ok_or("no Name property in desktop file")?;
   let exec = section.get("Exec").ok_or("no Exec property in desktop file")?;
-
+  if needs_xorg {
+    return Ok((name.to_string(), "startx ".to_owned() + &exec.to_string()))
+  }
   Ok((name.to_string(), exec.to_string()))
 }
 


### PR DESCRIPTION
To me it seems like we can assume that all entries in `xsessions` needs us to manually start x11 before we can properly execute them.

I've added a check for this in the code.
This helps me a lot as I have quite a few x11 session entries on my computer.
I didn't want to write custom scripts or everyone of them. Something like this seems like a better solution to me. 