### PR TITLE
Allow passing a username directly

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -86,6 +86,7 @@ pub struct Greeter {
 
   pub user_menu: bool,
 
+  pub default_user: Option<String>,
   pub remember: bool,
   pub remember_session: bool,
   pub remember_user_session: bool,
@@ -123,6 +124,10 @@ impl Greeter {
       if greeter.command.is_none() {
         greeter.command = Some(command.clone());
       }
+    }
+
+    if let Some(default_user) = greeter.default_user.clone() {
+        greeter.username = default_user;
     }
 
     if greeter.remember {
@@ -257,6 +262,7 @@ impl Greeter {
     opts.optopt("g", "greeting", "show custom text above login prompt", "GREETING");
     opts.optflag("t", "time", "display the current date and time");
     opts.optopt("", "time-format", "custom strftime format for displaying date and time", "FORMAT");
+    opts.optopt("u", "user", "set the default user", "USER");
     opts.optflag("r", "remember", "remember last logged-in username");
     opts.optflag("", "remember-session", "remember last selected session");
     opts.optflag("", "remember-user-session", "remember last selected session for each user");
@@ -349,6 +355,7 @@ impl Greeter {
       process::exit(1);
     }
 
+    self.default_user = self.option("user");
     self.remember = self.config().opt_present("remember");
     self.remember_session = self.config().opt_present("remember-session");
     self.remember_user_session = self.config().opt_present("remember-user-session");


### PR DESCRIPTION
Hello !
This is a proposal to add a new option `--user` (or `--default-user`) which would make possible to call `tuigreet` with a username to be pre-filled.
Of course, someone could already user the `--remember` but it could be useful to be able to 'hardcode' directly the desired username in the CLI arguments.

Note: I have almost 0 knowledge in Rust. The provided code has to be taken with care !