### PR TITLE
`XDG_SESSION_TYPE` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Options:
     -h, --help          show this usage information
     -v, --version       print version information
     -c, --cmd COMMAND   command to run
-    -s, --sessions DIRS colon-separated list of session paths
+    -s, --sessions DIRS colon-separated list of Wayland session paths
+    -x, --xsessions DIRS
+                        colon-separated list of X11 session paths
     -w, --width WIDTH   width of the main prompt (default: 80)
     -i, --issue         show the host's issue file
     -g, --greeting GREETING

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Options:
     -s, --sessions DIRS colon-separated list of Wayland session paths
     -x, --xsessions DIRS
                         colon-separated list of X11 session paths
+        --xsession-wrapper 'CMD [ARGS]...'
+                        wrapper command to initialize X server and launch X11
+                        sessions (default: startx /usr/bin/env)
     -w, --width WIDTH   width of the main prompt (default: 80)
     -i, --issue         show the host's issue file
     -g, --greeting GREETING

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Options:
         --xsession-wrapper 'CMD [ARGS]...'
                         wrapper command to initialize X server and launch X11
                         sessions (default: startx /usr/bin/env)
+        --no-xsession-wrapper
+                        do not wrap commands for X11 sessions
     -w, --width WIDTH   width of the main prompt (default: 80)
     -i, --issue         show the host's issue file
     -g, --greeting GREETING

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -33,6 +33,9 @@ tuigreet - A graphical console greeter for greetd
 	By default, *startx /usr/bin/env* will be prepended to all X11 session
 	commands.
 
+*--no-xsession-wrapper*
+	Do not wrap commands for X11 sessions.
+
 *-w, --width COLS*
 	Number of columns the main prompt area should take on the screen.
 

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -28,6 +28,11 @@ tuigreet - A graphical console greeter for greetd
 	Location of desktop-files to be used as X11 session definitions. By
 	default, X11 sessions are fetched from */usr/share/xsessions*.
 
+*--xsession-wrapper 'CMD [ARGS]...'*
+	Specify a wrapper command to initialize X server and launch X11 sessions.
+	By default, *startx /usr/bin/env* will be prepended to all X11 session
+	commands.
+
 *-w, --width COLS*
 	Number of columns the main prompt area should take on the screen.
 

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -21,9 +21,12 @@ tuigreet - A graphical console greeter for greetd
 	overridden by manual selection within *tuigreet*.
 
 *-s, --sessions DIR1[:DIR2]...*
-	Location of desktop-files to be used as session definitions. By default,
-	sessions are fetched from */usr/share/xsessions* and
-	*/usr/share/wayland-sessions*.
+	Location of desktop-files to be used as Wayland session definitions. By
+	default, Wayland sessions are fetched from */usr/share/wayland-sessions*.
+
+*-x, --xsessions DIR1[:DIR2]...*
+	Location of desktop-files to be used as X11 session definitions. By
+	default, X11 sessions are fetched from */usr/share/xsessions*.
 
 *-w, --width COLS*
 	Number of columns the main prompt area should take on the screen.

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -57,6 +57,12 @@ pub enum Mode {
 }
 
 #[derive(SmartDefault)]
+pub struct Session {
+  pub name: String,
+  pub command: String,
+}
+
+#[derive(SmartDefault)]
 pub struct Greeter {
   #[default(DEFAULT_LOCALE)]
   pub locale: Locale,
@@ -73,7 +79,7 @@ pub struct Greeter {
   pub command: Option<String>,
   pub new_command: String,
   pub sessions_path: Option<String>,
-  pub sessions: Vec<(String, String)>,
+  pub sessions: Vec<Session>,
   pub selected_session: usize,
 
   pub selected_power_option: usize,
@@ -119,7 +125,7 @@ impl Greeter {
     greeter.parse_options().await;
     greeter.sessions = crate::info::get_sessions(&greeter).unwrap_or_default();
 
-    if let Some((_, command)) = greeter.sessions.get(0) {
+    if let Some(Session { command, .. }) = greeter.sessions.get(0) {
       if greeter.command.is_none() {
         greeter.command = Some(command.clone());
       }
@@ -144,7 +150,7 @@ impl Greeter {
       }
     }
 
-    greeter.selected_session = greeter.sessions.iter().position(|(_, command)| Some(command) == greeter.command.as_ref()).unwrap_or(0);
+    greeter.selected_session = greeter.sessions.iter().position(|Session { command, .. }| Some(command) == greeter.command.as_ref()).unwrap_or(0);
 
     greeter
   }

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -56,10 +56,31 @@ pub enum Mode {
   Processing,
 }
 
+#[derive(SmartDefault, Debug, Copy, Clone, PartialEq)]
+pub enum SessionType {
+  X11,
+  Wayland,
+  TTY,
+  #[default]
+  None,
+}
+
+impl SessionType {
+  pub fn to_xdg_session_type(&self) -> &'static str {
+    match self {
+      SessionType::X11 => "x11",
+      SessionType::Wayland => "wayland",
+      SessionType::TTY => "tty",
+      SessionType::None => "unspecified",
+    }
+  }
+}
+
 #[derive(SmartDefault)]
 pub struct Session {
   pub name: String,
   pub command: String,
+  pub session_type: SessionType,
 }
 
 #[derive(SmartDefault)]

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -297,6 +297,7 @@ impl Greeter {
     opts.optopt("s", "sessions", "colon-separated list of Wayland session paths", "DIRS");
     opts.optopt("x", "xsessions", "colon-separated list of X11 session paths", "DIRS");
     opts.optopt("", "xsession-wrapper", xsession_wrapper_desc.as_str(), "'CMD [ARGS]...'");
+    opts.optflag("", "no-xsession-wrapper", "do not wrap commands for X11 sessions");
     opts.optopt("w", "width", "width of the main prompt (default: 80)", "WIDTH");
     opts.optflag("i", "issue", "show the host's issue file");
     opts.optopt("g", "greeting", "show custom text above login prompt", "GREETING");
@@ -409,7 +410,9 @@ impl Greeter {
       self.session_paths.extend(env::split_paths(&dirs).map(|dir| (dir, SessionType::X11)));
     }
 
-    self.xsession_wrapper = self.option("xsession-wrapper").or_else(|| Some(DEFAULT_XSESSION_WRAPPER.to_string()));
+    if !self.config().opt_present("no-xsession-wrapper") {
+      self.xsession_wrapper = self.option("xsession-wrapper").or_else(|| Some(DEFAULT_XSESSION_WRAPPER.to_string()));
+    }
 
     if self.config().opt_present("issue") {
       self.greeting = get_issue();

--- a/src/info.rs
+++ b/src/info.rs
@@ -10,7 +10,7 @@ use std::{
 use ini::Ini;
 use nix::sys::utsname;
 
-use crate::{Greeter, Session};
+use crate::{Greeter, Session, SessionType};
 
 const X_SESSIONS: &str = "/usr/share/xsessions";
 const WAYLAND_SESSIONS: &str = "/usr/share/wayland-sessions";
@@ -197,6 +197,7 @@ pub fn get_sessions(greeter: &Greeter) -> Result<Vec<Session>, Box<dyn Error>> {
       Session {
         name: command.clone(),
         command: command.clone(),
+        session_type: SessionType::default(),
       },
     );
   }
@@ -217,6 +218,7 @@ where
   Ok(Session {
     name: name.to_string(),
     command: exec.to_string(),
+    session_type: SessionType::default(),
   })
 }
 

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -21,8 +21,8 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
   let title = Span::from(titleize(&fl!("title_session")));
   let block = Block::default().title(title).borders(Borders::ALL).border_type(BorderType::Plain);
 
-  for (index, (name, _)) in greeter.sessions.iter().enumerate() {
-    let name = format!("{:1$}", name, greeter.width() as usize - 4);
+  for (index, session) in greeter.sessions.iter().enumerate() {
+    let name = format!("{:1$}", session.name, greeter.width() as usize - 4);
 
     let frame = Rect::new(x + 2, y + 2 + index as u16, width - 4, 1);
     let option_text = get_option(greeter, name, index);


### PR DESCRIPTION
Detect session type, store it and send to the greetd daemon. Wrap X11 sessions with a command to initialize X server.

Fixes gnome-shell session startup on distributions with systemd (see https://todo.sr.ht/~kennylevinsen/greetd/15).
Fixes #92
Supersedes #74 