### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Options:
 
 The default configuration tends to be as minimal as possible, visually speaking, only showing the authentication prompts and some minor information in the status bar. You may print your system's `/etc/issue` at the top of the prompt with `--issue` and the current date and time with `--time` (and possibly customize it with `--time-format`). You may include a custom one-line greeting message instead of `/etc/issue` with `--greeting`.
 
-The initial prompt container will be 80 column wide. You may change this with `--width` in case you need more space (for example, to account for large PAM challenge messages). Please refer to usage information (`--help`) for more customizaton options. Various padding settings are availble through the `*-padding` options.
+The initial prompt container will be 80 column wide. You may change this with `--width` in case you need more space (for example, to account for large PAM challenge messages). Please refer to usage information (`--help`) for more customization options. Various padding settings are available through the `*-padding` options.
 
 You can instruct `tuigreet` to remember the last username that successfully opened a session with the `--remember` option (that way, the username field will be pre-filled). Similarly, the command and session configuration can be retained between runs with the `--remember-session` option (when using this, the `--cmd` value is overridden by manual selections). You can also remember the selected session per user with the `--remember-user-session` flag. In this case, the selected session will only be saved on successful authentication.
 

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -18,7 +18,7 @@ tuigreet - A graphical console greeter for greetd
 
 *-c, --cmd CMD*
 	Specify which command to run on successful authentication. This can be
-	overriden by manual selection within *tuigreet*.
+	overridden by manual selection within *tuigreet*.
 
 *-s, --sessions DIR1[:DIR2]...*
 	Location of desktop-files to be used as session definitions. By default,


### PR DESCRIPTION
Found via `codespell -L crate,comando,nome,nowe,sie`