### PR TITLE
Add a generic --session-wrapper for non-X11 sessions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Options:
     -v, --version       print version information
     -c, --cmd COMMAND   command to run
     -s, --sessions DIRS colon-separated list of Wayland session paths
+        --session-wrapper 'CMD [ARGS]...'
+                        wrapper command to initialize the non-X11 session
     -x, --xsessions DIRS
                         colon-separated list of X11 session paths
         --xsession-wrapper 'CMD [ARGS]...'

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -24,6 +24,10 @@ tuigreet - A graphical console greeter for greetd
 	Location of desktop-files to be used as Wayland session definitions. By
 	default, Wayland sessions are fetched from */usr/share/wayland-sessions*.
 
+*--session-wrapper 'CMD [ARGS]...'*
+	Specify a wrapper command to execute instead of the session for non-X11
+	sessions. This command will receive the session command as its arguments.
+
 *-x, --xsessions DIR1[:DIR2]...*
 	Location of desktop-files to be used as X11 session definitions. By
 	default, X11 sessions are fetched from */usr/share/xsessions*.

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -85,6 +85,7 @@ pub struct Greeter {
   pub session_path: Option<PathBuf>,
   pub session_paths: Vec<(PathBuf, SessionType)>,
   pub sessions: Menu<Session>,
+  pub session_wrapper: Option<String>,
   pub xsession_wrapper: Option<String>,
 
   pub username: String,
@@ -296,6 +297,7 @@ impl Greeter {
     opts.optflag("v", "version", "print version information");
     opts.optopt("c", "cmd", "command to run", "COMMAND");
     opts.optopt("s", "sessions", "colon-separated list of Wayland session paths", "DIRS");
+    opts.optopt("", "session-wrapper", "wrapper command to initialize the non-X11 session", "'CMD [ARGS]...'");
     opts.optopt("x", "xsessions", "colon-separated list of X11 session paths", "DIRS");
     opts.optopt("", "xsession-wrapper", xsession_wrapper_desc.as_str(), "'CMD [ARGS]...'");
     opts.optflag("", "no-xsession-wrapper", "do not wrap commands for X11 sessions");
@@ -413,6 +415,10 @@ impl Greeter {
 
     if let Some(dirs) = self.option("xsessions") {
       self.session_paths.extend(env::split_paths(&dirs).map(|dir| (dir, SessionType::X11)));
+    }
+
+    if self.option("session-wrapper").is_some() {
+      self.session_wrapper = self.option("session-wrapper");
     }
 
     if !self.config().opt_present("no-xsession-wrapper") {

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -165,20 +165,17 @@ impl Greeter {
 
     if greeter.remember_session {
       if let Ok(session_path) = get_last_session_path() {
-        greeter.session_path = Some(session_path);
-      }
+        greeter.session_path = Some(session_path.clone());
 
-      if let Ok(command) = get_last_session() {
+        if let Some(session) = Session::from_path(&greeter, session_path) {
+          greeter.command = Some(session.command.clone());
+        }
+      } else if let Ok(command) = get_last_session() {
         greeter.command = Some(command.trim().to_string());
       }
     }
 
-    greeter.sessions.selected = greeter
-      .sessions
-      .options
-      .iter()
-      .position(|Session { path, .. }| path.as_deref() == greeter.session_path.as_deref())
-      .unwrap_or(0);
+    greeter.sessions.selected = greeter.sessions.options.iter().position(|Session { path, .. }| path == &greeter.session_path).unwrap_or(0);
 
     greeter
   }

--- a/src/info.rs
+++ b/src/info.rs
@@ -112,11 +112,11 @@ pub fn write_last_username(username: &str, name: Option<&str>) {
 }
 
 pub fn get_last_session_path() -> Result<PathBuf, io::Error> {
-  Ok(PathBuf::from(fs::read_to_string(LAST_SESSION_PATH)?))
+  Ok(PathBuf::from(fs::read_to_string(LAST_SESSION_PATH)?.trim()))
 }
 
 pub fn get_last_session() -> Result<String, io::Error> {
-  fs::read_to_string(LAST_SESSION)
+  Ok(fs::read_to_string(LAST_SESSION)?.trim().to_string())
 }
 
 pub fn write_last_session_path<P>(session: &P)
@@ -131,11 +131,11 @@ pub fn write_last_session(session: &str) {
 }
 
 pub fn get_last_user_session_path(username: &str) -> Result<PathBuf, io::Error> {
-  Ok(PathBuf::from(fs::read_to_string(format!("{LAST_SESSION_PATH}-{username}"))?))
+  Ok(PathBuf::from(fs::read_to_string(format!("{LAST_SESSION_PATH}-{username}"))?.trim()))
 }
 
 pub fn get_last_user_session(username: &str) -> Result<String, io::Error> {
-  fs::read_to_string(format!("{LAST_SESSION}-{username}"))
+  Ok(fs::read_to_string(format!("{LAST_SESSION}-{username}"))?.trim().to_string())
 }
 
 pub fn write_last_user_session_path<P>(username: &str, session: P)
@@ -151,6 +151,10 @@ pub fn delete_last_session_path() {
 
 pub fn write_last_user_session(username: &str, session: &str) {
   let _ = fs::write(format!("{LAST_SESSION}-{username}"), session);
+}
+
+pub fn delete_last_user_session_path(username: &str) {
+  let _ = fs::remove_file(format!("{LAST_SESSION_PATH}-{username}"));
 }
 
 pub fn get_users(min_uid: u16, max_uid: u16) -> Vec<User> {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -135,7 +135,11 @@ impl Ipc {
               if let Some(ref wrap) = greeter.xsession_wrapper {
                 command = format!("{} {}", wrap, command);
               }
+            } else if let Some(ref wrap) = greeter.session_wrapper {
+              command = format!("{} {}", wrap, command);
             }
+          } else if let Some(ref wrap) = greeter.session_wrapper {
+            command = format!("{} {}", wrap, command);
           }
 
           #[cfg(not(debug_assertions))]

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use crate::Greeter;
 
 use super::common::menu::MenuItem;
 
@@ -33,5 +35,152 @@ pub struct Session {
 impl MenuItem for Session {
   fn format(&self) -> String {
     self.name.clone()
+  }
+}
+
+impl Session {
+  pub fn from_path<P>(greeter: &Greeter, path: P) -> Option<&Session>
+  where
+    P: AsRef<Path>,
+  {
+    greeter.sessions.options.iter().find(|session| session.path.as_deref() == Some(path.as_ref()))
+  }
+
+  pub fn get_selected(greeter: &Greeter) -> Option<&Session> {
+    greeter.session_path.as_ref()?;
+    greeter.sessions.options.get(greeter.sessions.selected)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use crate::{
+    ui::{
+      common::menu::Menu,
+      sessions::{Session, SessionType},
+    },
+    Greeter,
+  };
+
+  #[test]
+  fn from_path_existing() {
+    let mut greeter = Greeter::default();
+    greeter.session_path = Some("/Session2Path".into());
+
+    greeter.sessions = Menu::<Session> {
+      title: "Sessions".into(),
+      selected: 1,
+      options: vec![
+        Session {
+          name: "Session1".into(),
+          command: "Session1Cmd".into(),
+          session_type: super::SessionType::Wayland,
+          path: Some("/Session1Path".into()),
+        },
+        Session {
+          name: "Session2".into(),
+          command: "Session2Cmd".into(),
+          session_type: super::SessionType::X11,
+          path: Some("/Session2Path".into()),
+        },
+      ],
+    };
+
+    let session = Session::from_path(&greeter, "/Session2Path");
+
+    assert!(matches!(session, Some(_)));
+    assert_eq!(session.unwrap().name, "Session2");
+    assert_eq!(session.unwrap().session_type, SessionType::X11);
+  }
+
+  #[test]
+  fn from_path_non_existing() {
+    let mut greeter = Greeter::default();
+    greeter.session_path = Some("/Session2Path".into());
+
+    greeter.sessions = Menu::<Session> {
+      title: "Sessions".into(),
+      selected: 1,
+      options: vec![Session {
+        name: "Session1".into(),
+        command: "Session1Cmd".into(),
+        session_type: super::SessionType::Wayland,
+        path: Some("/Session1Path".into()),
+      }],
+    };
+
+    let session = Session::from_path(&greeter, "/Session2Path");
+
+    assert!(matches!(session, None));
+  }
+
+  #[test]
+  fn no_session() {
+    let greeter = Greeter::default();
+
+    assert!(matches!(Session::get_selected(&greeter), None));
+  }
+
+  #[test]
+  fn distinct_session() {
+    let mut greeter = Greeter::default();
+    greeter.session_path = Some("/Session2Path".into());
+
+    greeter.sessions = Menu::<Session> {
+      title: "Sessions".into(),
+      selected: 1,
+      options: vec![
+        Session {
+          name: "Session1".into(),
+          command: "Session1Cmd".into(),
+          session_type: super::SessionType::Wayland,
+          path: Some("/Session1Path".into()),
+        },
+        Session {
+          name: "Session2".into(),
+          command: "Session2Cmd".into(),
+          session_type: super::SessionType::X11,
+          path: Some("/Session2Path".into()),
+        },
+      ],
+    };
+
+    let session = Session::get_selected(&greeter);
+
+    assert!(matches!(session, Some(_)));
+    assert_eq!(session.unwrap().name, "Session2");
+    assert_eq!(session.unwrap().session_type, SessionType::X11);
+  }
+
+  #[test]
+  fn same_name_session() {
+    let mut greeter = Greeter::default();
+    greeter.session_path = Some("/Session2Path".into());
+
+    greeter.sessions = Menu::<Session> {
+      title: "Sessions".into(),
+      selected: 1,
+      options: vec![
+        Session {
+          name: "Session".into(),
+          command: "Session1Cmd".into(),
+          session_type: super::SessionType::Wayland,
+          path: Some("/Session1Path".into()),
+        },
+        Session {
+          name: "Session".into(),
+          command: "Session2Cmd".into(),
+          session_type: super::SessionType::X11,
+          path: Some("/Session2Path".into()),
+        },
+      ],
+    };
+
+    let session = Session::get_selected(&greeter);
+
+    assert!(matches!(session, Some(_)));
+    assert_eq!(session.unwrap().name, "Session");
+    assert_eq!(session.unwrap().session_type, SessionType::X11);
+    assert_eq!(session.unwrap().command, "Session2Cmd");
   }
 }


### PR DESCRIPTION
X11 sessions got their own `--xsession-wrapper` which, on top of being able to start an X server, could allow people to wrap the session into their own script to set up the environment. No such feature existed for other kinds of sessions.

This adds that.

Relates to #109.