### PR TITLE
Add Text Align option

### DIFF
--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -106,8 +106,8 @@ tuigreet - A graphical console greeter for greetd
 	Add spacing between form fields.
 
 *--greet-align [left|center|right]*
-    Alignment of the greeting text in the main prompt container
-    (default: 'center')
+	Alignment of the greeting text in the main prompt container
+	(default: 'center').
 
 *--power-shutdown CMD [ARGS]...*
 	Customize the command run when instructed to shut down the machine. This must

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -105,6 +105,10 @@ tuigreet - A graphical console greeter for greetd
 *--prompt-padding ROWS*
 	Add spacing between form fields.
 
+*--greet-align [left|center|right]*
+    Alignment of the greeting text in the main prompt container
+    (default: 'center')
+
 *--power-shutdown CMD [ARGS]...*
 	Customize the command run when instructed to shut down the machine. This must
 	be a non-interactive command (sudo cannot prompt for a password, for example).

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -92,7 +92,7 @@ impl SecretDisplay {
 
 // This enum models text alignment options
 #[derive(SmartDefault, Debug, Clone)]
-pub enum TextAlign {
+pub enum GreetAlign {
   #[default]
   Center,
   Left,
@@ -349,15 +349,15 @@ impl Greeter {
     1
   }
 
-  pub fn text_align(&self) -> TextAlign {
-    if let Some(value) = self.option("text-align") {
+  pub fn greet_align(&self) -> GreetAlign {
+    if let Some(value) = self.option("greet-align") {
       match value.to_uppercase().as_str() {
-        "LEFT" | "L" => TextAlign::Left,
-        "RIGHT" | "R" => TextAlign::Right,
-        _ => TextAlign::Center
+        "left" => GreetAlign::Left,
+        "right" => GreetAlign::Right,
+        _ => GreetAlign::Center
       }
     } else {
-      TextAlign::default()
+      GreetAlign::default()
     }
   }
 
@@ -405,7 +405,7 @@ impl Greeter {
     opts.optopt("", "window-padding", "padding inside the terminal area (default: 0)", "PADDING");
     opts.optopt("", "container-padding", "padding inside the main prompt container (default: 1)", "PADDING");
     opts.optopt("", "prompt-padding", "padding between prompt rows (default: 1)", "PADDING");
-    opts.optopt("", "text-align", "alignment of text in the prompt container (default: 'center')", "[left|center|right]");
+    opts.optopt("", "greet-align", "alignment of the greeting text in the main prompt container (default: 'center')", "[left|center|right]");
 
     opts.optopt("", "power-shutdown", "command to run to shut down the system", "'CMD [ARGS]...'");
     opts.optopt("", "power-reboot", "command to run to reboot the system", "'CMD [ARGS]...'");

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -90,6 +90,15 @@ impl SecretDisplay {
   }
 }
 
+// This enum models text alignment options
+#[derive(SmartDefault, Debug, Clone)]
+pub enum TextAlign {
+  #[default]
+  Center,
+  Left,
+  Right
+}
+
 #[derive(SmartDefault)]
 pub struct Greeter {
   pub debug: bool,
@@ -270,7 +279,7 @@ impl Greeter {
     self.connect().await;
   }
 
-  // Connect to `greetd` and return a strea we can safely write to.
+  // Connect to `greetd` and return a stream we can safely write to.
   pub async fn connect(&mut self) {
     match UnixStream::connect(&self.socket).await {
       Ok(stream) => self.stream = Some(Arc::new(RwLock::new(stream))),
@@ -340,6 +349,18 @@ impl Greeter {
     1
   }
 
+  pub fn text_align(&self) -> TextAlign {
+    if let Some(value) = self.option("text-align") {
+      match value.to_uppercase().as_str() {
+        "LEFT" | "L" => TextAlign::Left,
+        "RIGHT" | "R" => TextAlign::Right,
+        _ => TextAlign::Center
+      }
+    } else {
+      TextAlign::default()
+    }
+  }
+
   // Sets the locale that will be used for this invocation from environment.
   fn set_locale(&mut self) {
     let locale = DesktopLanguageRequester::requested_languages()
@@ -384,6 +405,7 @@ impl Greeter {
     opts.optopt("", "window-padding", "padding inside the terminal area (default: 0)", "PADDING");
     opts.optopt("", "container-padding", "padding inside the main prompt container (default: 1)", "PADDING");
     opts.optopt("", "prompt-padding", "padding between prompt rows (default: 1)", "PADDING");
+    opts.optopt("", "text-align", "alignment of text in the prompt container (default: 'center')", "[left|center|right]");
 
     opts.optopt("", "power-shutdown", "command to run to shut down the system", "'CMD [ARGS]...'");
     opts.optopt("", "power-reboot", "command to run to reboot the system", "'CMD [ARGS]...'");

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -351,7 +351,7 @@ impl Greeter {
 
   pub fn greet_align(&self) -> GreetAlign {
     if let Some(value) = self.option("greet-align") {
-      match value.to_uppercase().as_str() {
+      match value.as_str() {
         "left" => GreetAlign::Left,
         "right" => GreetAlign::Right,
         _ => GreetAlign::Center

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -7,7 +7,11 @@ use tui::{
   widgets::{Block, BorderType, Borders, Paragraph},
 };
 
-use crate::{info::get_hostname, ui::{prompt_value, util::*, Frame}, Greeter, Mode, SecretDisplay, TextAlign};
+use crate::{
+  info::get_hostname,
+  ui::{prompt_value, util::*, Frame},
+  Greeter, Mode, SecretDisplay, GreetAlign
+};
 
 use super::common::style::Themed;
 
@@ -23,10 +27,10 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
 
   let container_padding = greeter.container_padding();
   let prompt_padding = greeter.prompt_padding();
-  let text_alignment = match greeter.text_align() {
-    TextAlign::Center => Alignment::Center,
-    TextAlign::Left => Alignment::Left,
-    TextAlign::Right => Alignment::Right
+  let greeting_alignment = match greeter.greet_align() {
+    GreetAlign::Center => Alignment::Center,
+    GreetAlign::Left => Alignment::Left,
+    GreetAlign::Right => Alignment::Right
   };
 
   let container = Rect::new(x, y, width, height);
@@ -60,7 +64,7 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
 
   if let Some(greeting) = &greeting {
     let greeting_text = greeting.trim_end();
-    let greeting_label = Paragraph::new(greeting_text).alignment(text_alignment).style(theme.of(&[Themed::Greet]));
+    let greeting_label = Paragraph::new(greeting_text).alignment(greeting_alignment).style(theme.of(&[Themed::Greet]));
 
     f.render_widget(greeting_label, chunks[GREETING_INDEX]);
   }
@@ -68,7 +72,7 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
   let username_label = if greeter.user_menu && greeter.username.value.is_empty() {
     let prompt_text = Span::from(fl!("select_user"));
 
-    Paragraph::new(prompt_text).alignment(text_alignment)
+    Paragraph::new(prompt_text).alignment(Alignment::Center)
   } else {
     let username_text = prompt_value(theme, Some(fl!("username")));
 
@@ -134,7 +138,7 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
 
       if let Some(message) = message {
         let message_text = Text::from(message);
-        let message = Paragraph::new(message_text).alignment(text_alignment);
+        let message = Paragraph::new(message_text).alignment(Alignment::Center);
 
         f.render_widget(message, Rect::new(x, y + height, width, message_height));
       }

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -7,11 +7,7 @@ use tui::{
   widgets::{Block, BorderType, Borders, Paragraph},
 };
 
-use crate::{
-  info::get_hostname,
-  ui::{prompt_value, util::*, Frame},
-  Greeter, Mode, SecretDisplay,
-};
+use crate::{info::get_hostname, ui::{prompt_value, util::*, Frame}, Greeter, Mode, SecretDisplay, TextAlign};
 
 use super::common::style::Themed;
 
@@ -27,6 +23,11 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
 
   let container_padding = greeter.container_padding();
   let prompt_padding = greeter.prompt_padding();
+  let text_alignment = match greeter.text_align() {
+    TextAlign::Center => Alignment::Center,
+    TextAlign::Left => Alignment::Left,
+    TextAlign::Right => Alignment::Right
+  };
 
   let container = Rect::new(x, y, width, height);
   let frame = Rect::new(x + container_padding, y + container_padding, width - (2 * container_padding), height - (2 * container_padding));
@@ -59,7 +60,7 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
 
   if let Some(greeting) = &greeting {
     let greeting_text = greeting.trim_end();
-    let greeting_label = Paragraph::new(greeting_text).alignment(Alignment::Center).style(theme.of(&[Themed::Greet]));
+    let greeting_label = Paragraph::new(greeting_text).alignment(text_alignment).style(theme.of(&[Themed::Greet]));
 
     f.render_widget(greeting_label, chunks[GREETING_INDEX]);
   }
@@ -67,7 +68,7 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
   let username_label = if greeter.user_menu && greeter.username.value.is_empty() {
     let prompt_text = Span::from(fl!("select_user"));
 
-    Paragraph::new(prompt_text).alignment(Alignment::Center)
+    Paragraph::new(prompt_text).alignment(text_alignment)
   } else {
     let username_text = prompt_value(theme, Some(fl!("username")));
 
@@ -133,7 +134,7 @@ pub fn draw(greeter: &mut Greeter, f: &mut Frame) -> Result<(u16, u16), Box<dyn 
 
       if let Some(message) = message {
         let message_text = Text::from(message);
-        let message = Paragraph::new(message_text).alignment(Alignment::Center);
+        let message = Paragraph::new(message_text).alignment(text_alignment);
 
         f.render_widget(message, Rect::new(x, y + height, width, message_height));
       }


### PR DESCRIPTION
Hi

I added a text-align option to the prompt. I did this mainly so ASCII art I had in my `/etc/issue` showed up better, but I can see it being useful for other things as well.

I am not sure if you would rather include this in the new theme flag I saw recently added, but I wasn't sure how to properly extend the format to accommodate that so I added it as a new flag. Leaving the flag absent defaults to center align as before.