### PR TITLE
Add Chinese (zh-CN) locale

### DIFF
--- a/contrib/locales/zh-CN/tuigreet.ftl
+++ b/contrib/locales/zh-CN/tuigreet.ftl
@@ -1,0 +1,29 @@
+title_authenticate = 认证到主机 {$hostname}
+title_command = 更改会话命令
+title_power = 电源选项
+title_session = 更改会话
+title_users = 选择用户
+
+action_reset = 重置
+action_command = 命令
+action_session = 会话
+action_power = 电源
+
+date = %a, %d %h %Y - %H:%M
+
+select_user = 回车键以选择用户或直接输入...
+username = 用户名:
+password = 密码:
+wait = 请稍候...
+failed = 认证失败，请重试。
+
+new_command = 新命令:
+
+shutdown = 关机
+reboot = 重启
+
+command_exited = 退出代码
+command_failed = 命令执行失败
+
+status_command = CMD
+status_caps = CAPS LOCK

--- a/contrib/locales/zh-CN/tuigreet.ftl
+++ b/contrib/locales/zh-CN/tuigreet.ftl
@@ -9,13 +9,13 @@ action_command = 命令
 action_session = 会话
 action_power = 电源
 
-date = %a, %d %h %Y - %H:%M
+date = %x, %A - %H:%M
 
-select_user = 回车键以选择用户或直接输入...
+select_user = 回车键以选择用户或直接输入用户名...
 username = 用户名:
 password = 密码:
 wait = 请稍候...
-failed = 认证失败，请重试。
+failed = 认证失败，请重试
 
 new_command = 新命令:
 
@@ -26,4 +26,4 @@ command_exited = 退出代码
 command_failed = 命令执行失败
 
 status_command = CMD
-status_caps = CAPS LOCK
+status_caps = 大小写锁定


### PR DESCRIPTION
I have a linux patch from https://github.com/zhmars/cjktty-patches and thus can display Chinese character in tty. 
This pr will break users with zh-CN locale who have not applied that patch, while they could have fallback to English instead.