### PR TITLE
Add notice on possible missing cache dir and link to cache instr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The default configuration tends to be as minimal as possible, visually speaking,
 
 The initial prompt container will be 80 column wide. You may change this with `--width` in case you need more space (for example, to account for large PAM challenge messages). Please refer to usage information (`--help`) for more customization options. Various padding settings are available through the `*-padding` options.
 
-You can instruct `tuigreet` to remember the last username that successfully opened a session with the `--remember` option (that way, the username field will be pre-filled). Similarly, the command and session configuration can be retained between runs with the `--remember-session` option (when using this, the `--cmd` value is overridden by manual selections). You can also remember the selected session per user with the `--remember-user-session` flag. In this case, the selected session will only be saved on successful authentication.
+You can instruct `tuigreet` to remember the last username that successfully opened a session with the `--remember` option (that way, the username field will be pre-filled). Similarly, the command and session configuration can be retained between runs with the `--remember-session` option (when using this, the `--cmd` value is overridden by manual selections). You can also remember the selected session per user with the `--remember-user-session` flag. In this case, the selected session will only be saved on successful authentication. Check the [cache instructions](#cache-instructions) if `/var/cache/tuigreet` doesn't exist after installing tuigreet.
 
 You may change the command that will be executed after opening a session by hitting `F2` and amending the command. Alternatively, you can list the system-declared sessions (or custom ones) by hitting `F3`. Power options are available through `F12`.
 
@@ -85,6 +85,7 @@ $ cargo build --release
 # mv target/release/tuigreet /usr/local/bin/tuigreet
 ```
 
+<a id="cache-instructions"></a>
 Cache directory must be created for `--remember*` features to work. The directory must be owned by the user running the greeter.
 
 ```


### PR DESCRIPTION
Some distributions (e.g., Arch, Fedora, OpenSUSE Tumbleweed) happen to be missing the setup of `/var/cache/tuigreet`, which leads to the --remember* options not working without running the cache instructions that are only mentioned for manual installs.