### PR TITLE
Add option to specify environment for default session

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Options:
     -d, --debug [FILE]  enable debug logging to the provided file, or to
                         /tmp/tuigreet.log
     -c, --cmd COMMAND   command to run
+        --env KEY=VALUE environment variables to run the default session with
+                        (can appear more than once)
     -s, --sessions DIRS colon-separated list of Wayland session paths
         --session-wrapper 'CMD [ARGS]...'
                         wrapper command to initialize the non-X11 session
@@ -40,9 +42,7 @@ Options:
                         minimum UID to display in the user selection menu
         --user-menu-max-uid UID
                         maximum UID to display in the user selection menu
-        --theme SPEC
-                        Add visual feedback when typing secrets, as one asterisk character for every
-                        keystroke. By default, no feedback is given at all.
+        --theme THEME   define the application theme colors
         --asterisks     display asterisks when a secret is typed
         --asterisks-char CHARS
                         characters to be used to redact secrets (default: *)
@@ -52,15 +52,21 @@ Options:
                         padding inside the main prompt container (default: 1)
         --prompt-padding PADDING
                         padding between prompt rows (default: 1)
+        --greet-align [left|center|right]
+                        alignment of the greeting text in the main prompt
+                        container (default: 'center')
         --power-shutdown 'CMD [ARGS]...'
                         command to run to shut down the system
         --power-reboot 'CMD [ARGS]...'
                         command to run to reboot the system
         --power-no-setsid
                         do not prefix power commands with setsid
-        --kb-[command|sessions|power] [1-12]
-                        change the default F-key keybindings to access the
-                        command, sessions and power menus.
+        --kb-command [1-12]
+                        F-key to use to open the command menu
+        --kb-sessions [1-12]
+                        F-key to use to open the sessions menu
+        --kb-power [1-12]
+                        F-key to use to open the power menu
 ```
 
 ## Usage

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -24,6 +24,9 @@ tuigreet - A graphical console greeter for greetd
 	Specify which command to run on successful authentication. This can be
 	overridden by manual selection within *tuigreet*.
 
+*--env KEY=VALUE*
+	Environment variables to run the default session with (can appear more then once).
+
 *-s, --sessions DIR1[:DIR2]...*
 	Location of desktop-files to be used as Wayland session definitions. By
 	default, Wayland sessions are fetched from */usr/share/wayland-sessions*.

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -339,6 +339,13 @@ impl Greeter {
     self.config().opt_str(name)
   }
 
+  pub fn options_multi(&self, name: &str) -> Option<Vec<String>> {
+    match self.config().opt_present(name) {
+      true => Some(self.config().opt_strs(name)),
+      false => None,
+    }
+  }
+
   // Returns the width of the main window where content is displayed from the
   // provided arguments.
   pub fn width(&self) -> u16 {
@@ -419,6 +426,7 @@ impl Greeter {
     opts.optflag("v", "version", "print version information");
     opts.optflagopt("d", "debug", "enable debug logging to the provided file, or to /tmp/tuigreet.log", "FILE");
     opts.optopt("c", "cmd", "command to run", "COMMAND");
+    opts.optmulti("", "env", "environment variables to run the default session with (can appear more than once)", "KEY=VALUE");
     opts.optopt("s", "sessions", "colon-separated list of Wayland session paths", "DIRS");
     opts.optopt("", "session-wrapper", "wrapper command to initialize the non-X11 session", "'CMD [ARGS]...'");
     opts.optopt("x", "xsessions", "colon-separated list of X11 session paths", "DIRS");
@@ -559,7 +567,7 @@ impl Greeter {
 
     // If the `--cmd` argument is provided, it will override the selected session.
     if let Some(command) = self.option("cmd") {
-      self.session_source = SessionSource::Command(command);
+      self.session_source = SessionSource::DefaultCommand(command, self.options_multi("env"));
     }
 
     if let Some(dirs) = self.option("sessions") {

--- a/src/ui/common/style.rs
+++ b/src/ui/common/style.rs
@@ -61,16 +61,16 @@ impl Theme {
     }
 
     if style.time.is_none() {
-      style.time = style.text.clone();
+      style.time.clone_from(&style.text);
     }
     if style.greet.is_none() {
-      style.greet = style.text.clone();
+      style.greet.clone_from(&style.text);
     }
     if style.title.is_none() {
-      style.title = style.border.clone();
+      style.title.clone_from(&style.border);
     }
     if style.button.is_none() {
-      style.button = style.action.clone();
+      style.button.clone_from(&style.action);
     }
 
     style

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -17,6 +17,7 @@ use super::common::menu::MenuItem;
 pub enum SessionSource {
   #[default]
   None,
+  DefaultCommand(String, Option<Vec<String>>),
   Command(String),
   Session(usize),
 }
@@ -29,6 +30,7 @@ impl SessionSource {
   pub fn label<'g, 'ss: 'g>(&'ss self, greeter: &'g Greeter) -> Option<&'g str> {
     match self {
       SessionSource::None => None,
+      SessionSource::DefaultCommand(command, _) => Some(command),
       SessionSource::Command(command) => Some(command),
       SessionSource::Session(index) => greeter.sessions.options.get(*index).map(|session| session.name.as_str()),
     }
@@ -39,8 +41,18 @@ impl SessionSource {
   pub fn command<'g, 'ss: 'g>(&'ss self, greeter: &'g Greeter) -> Option<&'g str> {
     match self {
       SessionSource::None => None,
+      SessionSource::DefaultCommand(command, _) => Some(command.as_str()),
       SessionSource::Command(command) => Some(command.as_str()),
       SessionSource::Session(index) => greeter.sessions.options.get(*index).map(|session| session.command.as_str()),
+    }
+  }
+
+  pub fn env<'g, 'ss: 'g>(&'ss self) -> Option<Vec<String>> {
+    match self {
+      SessionSource::None => None,
+      SessionSource::DefaultCommand(_, env) => env.clone(),
+      SessionSource::Command(_) => None,
+      SessionSource::Session(_) => None,
     }
   }
 }


### PR DESCRIPTION
When a session is specified through the `--cmd` argument, there is currently no way to set environment variables to run it with (other than creating a wrapper script). This adds an `--env` command line option to do exactly that.

Closes #148.