### PR TITLE
Add --silent flag to silence command output

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -186,6 +186,8 @@ pub struct Greeter {
   pub done: bool,
   // Should we exit?
   pub exit: Option<AuthStatus>,
+  // Should we silence command output?
+  pub silent: bool,
 }
 
 impl Drop for Greeter {
@@ -430,6 +432,7 @@ impl Greeter {
     opts.optflag("v", "version", "print version information");
     opts.optflagopt("d", "debug", "enable debug logging to the provided file, or to /tmp/tuigreet.log", "FILE");
     opts.optopt("c", "cmd", "command to run", "COMMAND");
+    opts.optflag("", "silent", "silence command output");
     opts.optmulti("", "env", "environment variables to run the default session with (can appear more than once)", "KEY=VALUE");
     opts.optopt("s", "sessions", "colon-separated list of Wayland session paths", "DIRS");
     opts.optopt("", "session-wrapper", "wrapper command to initialize the non-X11 session", "'CMD [ARGS]...'");
@@ -482,6 +485,8 @@ impl Greeter {
       Ok(matches) => Some(matches),
       Err(err) => return Err(err.into()),
     };
+
+    self.silent = self.config().opt_present("silent");
 
     if self.config().opt_present("help") {
       print_usage(opts);

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -244,6 +244,8 @@ impl<'a> DefaultCommand<'a> {
 fn wrap_session_command<'a>(greeter: &Greeter, session: Option<&Session>, default: &'a DefaultCommand<'a>) -> (Cow<'a, str>, Vec<String>) {
   let mut env: Vec<String> = vec![];
 
+  let mut command = Cow::Borrowed(default.command());
+
   match session {
     // If the target is a defined session, we should be able to deduce all the
     // environment we need from the desktop file.
@@ -266,10 +268,10 @@ fn wrap_session_command<'a>(greeter: &Greeter, session: Option<&Session>, defaul
 
       if *session_type == SessionType::X11 {
         if let Some(ref wrap) = greeter.xsession_wrapper {
-          return (Cow::Owned(format!("{} {}", wrap, default.command())), env);
+          command = Cow::Owned(format!("{} {}", wrap, default.command()));
         }
       } else if let Some(ref wrap) = greeter.session_wrapper {
-        return (Cow::Owned(format!("{} {}", wrap, default.command())), env);
+        command = Cow::Owned(format!("{} {}", wrap, default.command()));
       }
     }
 
@@ -277,7 +279,7 @@ fn wrap_session_command<'a>(greeter: &Greeter, session: Option<&Session>, defaul
       // If a wrapper script is used, assume that it is able to set up the
       // required environment.
       if let Some(ref wrap) = greeter.session_wrapper {
-        return (Cow::Owned(format!("{} {}", wrap, default.command())), env);
+        command = Cow::Owned(format!("{} {}", wrap, default.command()));
       }
       // Otherwise, set up the environment from the provided argument.
       if let Some(base_env) = default.env() {
@@ -286,7 +288,11 @@ fn wrap_session_command<'a>(greeter: &Greeter, session: Option<&Session>, defaul
     }
   }
 
-  (Cow::Borrowed(default.command()), env)
+  if greeter.silent {
+    (Cow::Owned(format!("{command} >/dev/null 2>&1")), env)
+  } else {
+    (command, env)
+  }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I'm creating this pull request to address an issue with verbose command output when using `tuigreet`.

When I use `tuigreet` to launch Hyprland (`tuigreet --cmd 'Hyprland'`), a lot of log messages are displayed after I log in.

I tried to fix this by redirecting the output like this: `tuigreet --cmd 'Hyprland >/dev/null 2>&1'`. While this did hide the log messages, the entire command, including the redirection, was then displayed in the `session_source` in the UI, which looked cluttered.

Therefore, I've added a `--silent` flag to provide a cleaner solution. This flag automatically handles the output redirection without affecting how the command is displayed in the UI.