### PR TITLE
feat: add battery level indicator to the top bar

### DIFF
--- a/contrib/locales/ca-ES/tuigreet.ftl
+++ b/contrib/locales/ca-ES/tuigreet.ftl
@@ -8,6 +8,7 @@ action_command = Canvia l'ordre
 action_session = Tria una sessió
 action_power = Engegada
 
+battery = Bateria: { $level }%
 date = %a %d %h %Y - %H:%M
 
 username = Nom d'usuari:

--- a/contrib/locales/de-DE/tuigreet.ftl
+++ b/contrib/locales/de-DE/tuigreet.ftl
@@ -8,6 +8,7 @@ action_command = Befehl ändern
 action_session = Sitzung auswählen
 action_power = Energie
 
+battery = Batterie: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 username = Benutzername:

--- a/contrib/locales/en-US/tuigreet.ftl
+++ b/contrib/locales/en-US/tuigreet.ftl
@@ -9,6 +9,7 @@ action_command = Change command
 action_session = Choose session
 action_power = Power
 
+battery = Battery: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 select_user = Press Enter to select a user or start typing...

--- a/contrib/locales/es-CL/tuigreet.ftl
+++ b/contrib/locales/es-CL/tuigreet.ftl
@@ -9,6 +9,7 @@ action_command = Cambiar comando
 action_session = Escoger sesión
 action_power = Energía
 
+battery = Batería: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 select_user = Presiona Intro para seleccionar un usuario o comenzar a escribir...

--- a/contrib/locales/fr-FR/tuigreet.ftl
+++ b/contrib/locales/fr-FR/tuigreet.ftl
@@ -9,6 +9,7 @@ action_command = Changer la commande
 action_session = Choisir la session
 action_power = Alimentation
 
+battery = Batterie : { $level }%
 date = %a %d %h %Y - %H:%M
 
 select_user = Appuyez sur Entrée pour choisir un utilisateur ou tapez son nom...

--- a/contrib/locales/it-IT/tuigreet.ftl
+++ b/contrib/locales/it-IT/tuigreet.ftl
@@ -8,6 +8,7 @@ action_command = Cambia comando
 action_session = Scegli sessione
 action_power = Alimentazione
 
+battery = Batteria: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 username = Nome utente:

--- a/contrib/locales/pl-PL/tuigreet.ftl
+++ b/contrib/locales/pl-PL/tuigreet.ftl
@@ -10,6 +10,7 @@ action_command = Zmiana polecenia
 action_session = Wybór sesji
 action_power = Zasilanie
 
+battery = Bateria: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 select_user = Naciśnij Enter, by wybrać użytkownika, lub zacznij pisać...

--- a/contrib/locales/pt-BR/tuigreet.ftl
+++ b/contrib/locales/pt-BR/tuigreet.ftl
@@ -8,6 +8,7 @@ action_command = Mudar comando
 action_session = Escolher sessão
 action_power = Energia
 
+battery = Bateria: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 username = Nome de usuário:

--- a/contrib/locales/ru-RU/tuigreet.ftl
+++ b/contrib/locales/ru-RU/tuigreet.ftl
@@ -9,6 +9,7 @@ action_command = Изменить команду
 action_session = Выбрать сеанс
 action_power = Питание
 
+battery = Baterie: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 select_user = Нажмите Enter для выбора пользователя или начните печатать...

--- a/contrib/locales/uk-UA/tuigreet.ftl
+++ b/contrib/locales/uk-UA/tuigreet.ftl
@@ -9,6 +9,7 @@ action_command = Змінити команду
 action_session = Вибрати сесію
 action_power = Живлення
 
+battery = Battery: { $level }%
 date = %a, %d %h %Y - %H:%M
 
 select_user = Натисніть Enter щоб вибрати користувача або введіть його ім'я...

--- a/contrib/man/tuigreet-1.scd
+++ b/contrib/man/tuigreet-1.scd
@@ -63,6 +63,9 @@ tuigreet - A graphical console greeter for greetd
 *-t, --time*
 	Print the current date and time at the top of the screen.
 
+*-b, --battery*
+	Print current battery level at the top of the screen.
+
 *--time-format FORMAT*
 	Configure a custom strftime-compliant format string for the current date
 	and time.

--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -161,6 +161,8 @@ pub struct Greeter {
   pub theme: Theme,
   // Display the current time
   pub time: bool,
+  // Display the current battery level
+  pub battery: bool,
   // Time format
   pub time_format: Option<String>,
   // Greeting message (MOTD) to use to welcome the user.
@@ -440,6 +442,7 @@ impl Greeter {
     opts.optflag("i", "issue", "show the host's issue file");
     opts.optopt("g", "greeting", "show custom text above login prompt", "GREETING");
     opts.optflag("t", "time", "display the current date and time");
+    opts.optflag("b", "battery", "display the current battery level");
     opts.optopt("", "time-format", "custom strftime format for displaying date and time", "FORMAT");
     opts.optflag("r", "remember", "remember last logged-in username");
     opts.optflag("", "remember-session", "remember last selected session");
@@ -526,6 +529,7 @@ impl Greeter {
     }
 
     self.time = self.config().opt_present("time");
+    self.battery = self.config().opt_present("battery");
 
     if let Some(format) = self.config().opt_str("time-format") {
       if StrftimeItems::new(&format).any(|item| item == Item::Error) {

--- a/src/info.rs
+++ b/src/info.rs
@@ -317,6 +317,24 @@ pub fn capslock_status() -> bool {
   }
 }
 
+pub fn get_battery_status() -> Option<String> {
+  if let Ok(entries) = fs::read_dir("/sys/class/power_supply/") {
+    for entry in entries.flatten() {
+      if let Some(name) = entry.file_name().to_str() {
+        if name.starts_with("BAT") {
+          let capacity_path = entry.path().join("capacity");
+
+          if let Ok(capacity) = fs::read_to_string(capacity_path) {
+            return Some(capacity.trim().to_string());
+          }
+        }
+      }
+    }
+  }
+
+  None
+}
+
 #[cfg(feature = "nsswrapper")]
 #[cfg(test)]
 mod nsswrapper_tests {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -70,11 +70,28 @@ where
       )
       .split(size);
 
-    if greeter.time {
-      let time_text = Span::from(get_time(&greeter));
-      let time = Paragraph::new(time_text).alignment(Alignment::Center).style(theme.of(&[Themed::Time]));
+    let mut top_bar_text = String::new();
 
-      f.render_widget(time, chunks[TITLEBAR_INDEX]);
+    if greeter.time {
+      top_bar_text.push_str(&get_time(&greeter));
+    }
+
+    if greeter.battery {
+      if let Some(level) = crate::info::get_battery_status() {
+        let battery_text = fl!("battery", level = level);
+
+        if !top_bar_text.is_empty() {
+          top_bar_text.push_str("   ");
+        }
+        top_bar_text.push_str(&battery_text);
+      }
+    }
+
+    if !top_bar_text.is_empty() {
+      let text = Span::from(top_bar_text);
+      let paragraph = Paragraph::new(text).alignment(Alignment::Center).style(theme.of(&[Themed::Time]));
+
+      f.render_widget(paragraph, chunks[TITLEBAR_INDEX]);
     }
 
     let status_block_size_right = 1 + greeter.window_padding() + fl!("status_caps").chars().count() as u16;


### PR DESCRIPTION
- Add `--battery` (and `-b`) flag to enable the battery indicator.
- Implement battery capacity fetching from `/sys/class/power_supply/`.
- Integrate the battery indicator into the UI title bar next to the date/time.
- Add internationalization support for "Battery" labels across all locales in `contrib/locales/`.

<img width="666" height="332" alt="swappy-20260427_203220" src="https://github.com/user-attachments/assets/04a55359-5df3-4de1-a46c-aaa0295a858d" />
<img width="663" height="335" alt="swappy-20260427_203310" src="https://github.com/user-attachments/assets/51ec4478-5ba3-4f3d-a1d1-da02f2c35ea2" />
